### PR TITLE
Ranger Whitelist patch #3 (this one works I promise) (#659)

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -163,12 +163,12 @@
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[den[name]]</td></tr>"
 			even = !even
 	if(leg.len > 0)
-		dat += "<tr><th colspan=3>Legion</th></tr>"
+		dat += "<tr><th colspan=3>Caesar's Legion</th></tr>"
 		for(var/name in leg)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[leg[name]]</td></tr>"
 			even = !even
 	if(ncr.len > 0)
-		dat += "<tr><th colspan=3>NCR</th></tr>"
+		dat += "<tr><th colspan=3>New California Republic</th></tr>"
 		for(var/name in ncr)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[name]</td><td>[ncr[name]]</td></tr>"
 			even = !even

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -696,7 +696,7 @@ Venator
 	H.add_quirk("Hard Yards")
 
 /datum/outfit/job/CaesarsLegion/Legionnaire/f13venator
-	name = "Legion Explorer"
+	name = "Legion Venator"
 	jobtype 	= /datum/job/CaesarsLegion/Legionnaire/f13explorer
 	id 			= 	/obj/item/card/id/dogtag/legvenator
 	suit 		= 	/obj/item/clothing/suit/armor/f13/legion/venator
@@ -708,7 +708,6 @@ Venator
 	backpack_contents = list(
 		/obj/item/restraints/legcuffs/bola=1, \
 		/obj/item/reagent_containers/pill/patch/healpoultice=2, \
-		/obj/item/flashlight/flare/torch=1, \
 		/obj/item/storage/bag/money/small/legenlisted,
 		/obj/item/radio)
 

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -713,8 +713,7 @@ Veteran Ranger
 	name = "Classic Veteran Ranger"
 	suit_store = /obj/item/gun/ballistic/shotgun/antimateriel
 	backpack_contents = list(
-		/obj/item/ammo_box/a50MG=2,
-		/obj/item/ammo_box/magazine/sniper_rounds/soporific=1)
+		/obj/item/ammo_box/a50MG=3)
 
 /datum/outfit/loadout/vrlite
 	name = "Light Veteran Ranger"
@@ -818,7 +817,7 @@ Ranger -- Split into Patrol and Scout
 
 	outfit = /datum/outfit/job/ncr/f13rangerpatrol
 
-/datum/job/ncr/f13ranger/after_spawn(mob/living/carbon/human/H, mob/M)
+/datum/job/ncr/f13rangerpatrol/after_spawn(mob/living/carbon/human/H, mob/M)
 	H.add_quirk("Hard Yards")
 
 /datum/outfit/job/ncr/f13ranger/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -868,7 +867,7 @@ Ranger -- Split into Patrol and Scout
 	/datum/outfit/loadout/rangertrail //M1 Garand and .44,
 	)
 
-/datum/job/ncr/f13ranger/after_spawn(mob/living/carbon/human/H, mob/M)
+/datum/job/ncr/f13rangerscout/after_spawn(mob/living/carbon/human/H, mob/M)
 	H.add_quirk("Hard Yards")
 	H.add_quirk("Light Step")
 

--- a/code/modules/jobs/job_whitelist.dm
+++ b/code/modules/jobs/job_whitelist.dm
@@ -113,7 +113,7 @@
 		for(var/rtypeWL in GLOB.faction_player_positions)
 			play_records[rtypeWL] = rtypeWL
 
-	if(!whitelists["ranger"])
+	if(whitelists["ranger"])
 		for(var/rtypeWL in GLOB.ncr_ranger_positions)
 			play_records[rtypeWL] = rtypeWL
 

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -160,7 +160,9 @@ GLOBAL_LIST_INIT(den_positions, list(
 	"Shopkeeper",
     "Farmer",
     "Prospector",
-	"Detective"
+	"Detective",
+	"Preacher",
+	"Barkeep"
 ))
 
 GLOBAL_LIST_INIT(legion_command_positions, list(
@@ -228,7 +230,6 @@ GLOBAL_LIST_INIT(vault_positions, list(
 GLOBAL_LIST_INIT(wasteland_positions, list(
     "Outlaw",
     "Great Khan",
-    "Preacher",
 	"Faithful",
     "Wastelander",
 ))


### PR DESCRIPTION
* venator and scout/patrol ranger

* Venator and Rangers

* Revert "Venator and Rangers" map changes

* Update Pahrump.dmm

* ranger

* Update automatic.dm

* vet legionary headsets

also a super cool wall safe hidden behind a poster that nobody will ever find

* corporal spawns

* loadout tweaks

* Crew Manifest & Ranger WL fix

* dungeon balancing

* Update Pahrump.dmm

* one more momma claw

* whitelist fix (third time's the charm)

* fixes hard yards for rangers

* Update datacore.dm

* Update ncr.dm

* Update legion.dm

<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:
